### PR TITLE
Add Bundler clean_env to rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,11 @@ task :db do
   puts "This script is going to drop your local database #{db_name} and fetch the database from heroku #{app}. Quit now if that doesn't sound good, or press any key to continue"
   STDIN.gets
 
-  sh "heroku pg:backups capture --app #{app}"
-  sh "curl -o latest.dump `heroku pg:backups public-url --app #{app}`"
-  sh "dropdb #{db_name}"
-  sh "createdb #{db_name}"
-  sh "pg_restore --verbose --clean --no-acl --no-owner -h localhost -U #{user} -d #{db_name} latest.dump"
+  Bundler.with_clean_env do
+    sh "heroku pg:backups capture --app #{app}"
+    sh "curl -o latest.dump `heroku pg:backups public-url --app #{app}`"
+    sh "dropdb #{db_name}"
+    sh "createdb #{db_name}"
+    sh "pg_restore --verbose --clean --no-acl --no-owner -h localhost -U #{user} -d #{db_name} latest.dump"
+  end
 end


### PR DESCRIPTION
This was causing Ruby errors on my machine before:
```
dyld: lazy symbol binding failed: Symbol not found: _rb_str_new_static
  Referenced from: /Users/fkrause/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/json-1.8.3/lib/json/ext/parser.bundle
  Expected in: flat namespace
```