### PR TITLE
Show mono-gem only by default

### DIFF
--- a/app/controllers/update_checks_controller.rb
+++ b/app/controllers/update_checks_controller.rb
@@ -43,12 +43,12 @@ class UpdateChecksController < ApplicationController
       watchbuild: "#000000",
       match: "#FD972D",
       screengrab: "#257E6D",
-      spaceship: "#000000"
+      spaceship: "#FF33AA"
     }
   end
 
   def graphs
-    show_fastlane = params[:fastlane] # as fastlane is launched far too often, it's hidden by default
+    all_tools = params[:all] # as by default we only show fastlane, as we deprecated the other gems
 
     @data = {}
     @days_raw = []
@@ -66,7 +66,7 @@ class UpdateChecksController < ApplicationController
     # Number of launches
     #
     Bacon.all.order(:launch_date).each do |bacon|
-      next if (!show_fastlane and bacon.tool == 'fastlane')
+      next if (!all_tools and bacon.tool != 'fastlane')
       next if (bacon.launch_date < start_time)
 
       @data[bacon.tool] ||= {

--- a/app/views/update_checks/graphs.html.erb
+++ b/app/views/update_checks/graphs.html.erb
@@ -18,7 +18,9 @@
 <% if fl_data %>
   <li>Total number of <i>fastlane</i> launches: <b><%= number_with_delimiter(fl_data[:data].last) %></b></li>
 <% end %>
-<li>Total number of launches of all tools: <b><%= number_with_delimiter(@cumulative.collect { |a| a[:data].last }.sum) %></b></li>
+<% if params[:all] %>
+  <li>Total number of launches of all tools: <b><%= number_with_delimiter(@cumulative.collect { |a| a[:data].last }.sum) %></b></li>
+<% end %>
 </ul>
 
 <h3>Cumulative launches</h3>


### PR DESCRIPTION
We've been showing all the tools here, however we actually want to focus on the monogem "fastlane" now